### PR TITLE
Remove use of sync functions for the asynchronous alternative

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,12 +9,14 @@ var systemPackages = ['fs', 'path', 'child_process'];
 function AutoInstall(){}
 
 
-function loadNaiConfig(directory){
-  var ret = {};
-  try{
-    ret = JSON.parse(fs.readFileSync(path.resolve(directory, './.nairc')));
-  }catch(ex){}
-  return ret;
+function loadNaiConfig(directory) {
+  return readFileIfExists(path.resolve(directory, './.nairc'))
+    .then(function(data) {
+      if (!data) {
+        return {};
+      }
+      return JSON.parse(data);
+    });
 }
 
 
@@ -54,7 +56,7 @@ function installPackages(npm, names) {
     if(!_.isEmpty(names)){
       debug('install npm package', names);
       npm.commands.install(names, function(err, data){
-        if(err) reject(err);
+        if(err) return reject(err);
         resolve(data);
       });
     }else{
@@ -69,7 +71,7 @@ function uninstallPackages(npm, names) {
       debug('uninstall npm package', names);
       npm.commands.uninstall(names, function(err, data){
         debug('uninstall result', err, data);
-        if(err) reject(err);
+        if(err) return reject(err);
         resolve(data);
       });
     }else{
@@ -102,7 +104,7 @@ function launchInstallUninstall(npm, options, ret) {
 function npmLoad(npm, directory){
   return new Promise(function(resolve, reject) {
     npm.load({silent: true, global: false}, function(err){
-      if(err) reject(err);
+      if(err) return reject(err);
       npm.config.set('save', true);
       npm.localPrefix = directory;
       resolve();
@@ -110,66 +112,124 @@ function npmLoad(npm, directory){
   });
 }
 
+function readFile(path) {
+  return new Promise(function(resolve, reject) {
+    fs.readFile(path, 'utf8', function(err, data) {
+      if (err) {
+        return reject(err);
+      }
+      resolve(data);
+    });
+  });
+};
+
+function readFileIfExists(path) {
+  return new Promise(function(resolve, reject) {
+    fs.access(path, function(err) {
+      if (err && err.code !== 'ENOENT') {
+        reject(err);
+      } else if (err) {
+        resolve(null);
+      } else {
+        readFile(path).then(resolve).catch(reject);
+      }
+    });
+  });
+};
+
 AutoInstall.prototype.detectMissing = function(directory, options) {
   // return Promise.resolve({installed:[], uninstalled:[], unused:[], missing:[]});
-  return new Promise(function (resolve, reject){
-    options = options || {};
-    debug('Call with options', options);
-    var ret = {
-      installed: [],
-      uninstalled: [],
-      missing: [],
-      unused: []
-    };
-    try{
-      fs.accessSync(path.resolve(directory, "./package.json"));
-      // Read package.json
-      var packageJson = JSON.parse(fs.readFileSync(path.resolve(directory, "./package.json"), 'utf8'));
+  options = options || {};
+  debug('Call with options', options);
+  var ret = {
+    installed: [],
+    uninstalled: [],
+    missing: [],
+    unused: []
+  };
+
+  var globPromise = function(globs, options) {
+    return new Promise(function(resolve, reject) {
+      glob(globs, options, function(err, files) {
+        if (err) {
+          return reject(err);
+        }
+        resolve(files);
+      });
+    });
+  };
+
+  var packageJsonPath = path.resolve(directory, './package.json');
+  var bowerRcPath = path.resolve(directory, './.bowerrc');
+  var ignoreFiles = ['node_modules/**', 'bower/**'];
+  var requires = {};
+  var packageJson, naiConfig;
+  // Read package.json
+  return readFileIfExists(packageJsonPath)
+    .then(function(data) {
+      packageJson = JSON.parse(data);
       // Search all js file
-      var ignoreFiles = ['node_modules/**', 'bower/**'];
-      if(options.ignore) { 
-        if(options.ignore instanceof Array) {
-            ignoreFiles = ignoreFiles.concat(options.ignore);
+      if (options.ignore) {
+        if (options.ignore instanceof Array) {
+          ignoreFiles = ignoreFiles.concat(options.ignore);
         } else {
-            ignoreFiles.push(options.ignore);
+          ignoreFiles.push(options.ignore);
         }
       }
-
-      // Add custom bower directory to ignore
-      try{
-        // Can't use require because no .json extension
-        var bowerRcJson = JSON.parse(fs.readFileSync(path.resolve(directory, './.bowerrc'), 'utf8'));
-        ignoreFiles.push(bowerRcJson.directory+"/**");
-      }catch(ex){} // No .bowerrc
-      var naiConfig = loadNaiConfig(directory);
-      if(naiConfig.ignore) naiConfig.ignore.forEach(function(i){ ignoreFiles.push(i); });
-
-      var files = glob.sync('**/*.js', {cwd: directory, ignore: ignoreFiles});
-      var requires = {};
-      files.forEach(function(f){
-        try{
-          debug('Parse file', f);
-          var code = fs.readFileSync(path.resolve(directory, f)).toString().replace('#!/usr/bin/env node', '');
-          var prog = require('esprima').parse(code, {tolerant: true});
-          // type: 'CallExpression' callee: { type: 'Identifier', name: 'require' }, arguments: [{value: 'koa-livereload'}]
-          findRequire(prog).forEach(function(r){
-            var temp = _.get(requires, r, []);
-            temp.push(f);
-            _.set(requires, r, temp);
-            // if(!_.includes(systemPackages, r)){
-            //   requires.push(r);
-            // }
+      return readFileIfExists(bowerRcPath);
+    })
+    .then(function(data) {
+      if (data) {
+        var bowerRcJson = JSON.parse(data);
+        ignoreFiles.push(bowerRcJson.directory + "/**");
+      }
+      return loadNaiConfig(directory);
+    })
+    .then(function(data) {
+      naiConfig = data;
+      if (naiConfig.ignore) {
+        naiConfig.ignore.forEach(function(f) {
+          ignoreFiles.push(f);
+        });
+      }
+      var globOptions = {
+        cwd: directory,
+        ignore: ignoreFiles
+      };
+      return globPromise('**/*.js', globOptions);
+    })
+    .then(function(files) {
+      return Promise.all(_.map(files, function(f) {
+        debug('Parse file', f);
+        return readFile(path.resolve(directory, f))
+          .then(function(data) {
+            var code = data.toString().replace('#!/usr/bin/env node', '');
+            // type: 'CallExpression' callee: { type: 'Identifier', name: 'require' }, arguments: [{value: 'koa-livereload'}]
+            var prog = require('esprima').parse(code, {
+              tolerant: true
+            });
+            findRequire(prog).forEach(function(r) {
+              var temp = _.get(requires, r, []);
+              temp.push(f);
+              _.set(requires, r, temp);
+              // if(!_.includes(systemPackages, r)){
+              //   requires.push(r);
+              // }
+            });
+          }).catch(function(err) {
+            debug('Error while parsing file', f, err);
           });
-        }catch(ex){
-          debug('Error while parsing file', f, ex);
-          reject(ex);
-        }
-      });
+      }));
+    })
+    .then(function() {
       // requires = _.uniq(requires);
       // Find missing and unused
       _.forEach(requires, function(v, r) {
-        if(!_.has(packageJson.dependencies, r) && !_.has(packageJson.devDependencies, r) && !_.includes(systemPackages, r)) {
-          ret.missing.push({name: r, files: v});
+        if(!_.has(packageJson.dependencies, r) && !_.has(packageJson.devDependencies, r) && !_.includes(systemPackages, r)){
+          ret.missing.push({
+            name: r,
+            files: v
+          });
         }
       });
       if(packageJson.dependencies){
@@ -186,15 +246,14 @@ AutoInstall.prototype.detectMissing = function(directory, options) {
           }
         });
       }
-
       // If something to install/uninstall
       if((!_.isEmpty(ret.unused) && options.uninstall) || (!_.isEmpty(ret.missing) && options.install)) {
         delete require.cache.npm;
         var npm = require('npm');
         /* istanbul ignore else  */
         if(options.force) {
-          npmLoad(npm, directory).then(function(){
-            return launchInstallUninstall(npm, options, ret).then(resolve).catch(reject);
+          return npmLoad(npm, directory).then(function() {
+            return launchInstallUninstall(npm, options, ret);
           });
         }else{
           var prompt = require("prompt");
@@ -206,24 +265,23 @@ AutoInstall.prototype.detectMissing = function(directory, options) {
             warning: 'Must respond yes or no',
             "default": 'yes'
           };
-          prompt.get(property, function(err, result) {
-            if (result.yesno === 'yes') {
-              npmLoad(npm, directory).then(function(){
-                return launchInstallUninstall(npm, options, ret).then(resolve).catch(reject);
-              });
-            } else {
-              reject(new Error("Abort install/uninstall"));
-            }
+          return new Promise(function(resolve, reject) {
+            prompt.get(property, function(err, result) {
+              if (result.yesno === 'yes') {
+                return npmLoad(npm, directory).then(function() {
+                  return launchInstallUninstall(npm, options, ret);
+                });
+              } else {
+                reject(new Error("Abort install/uninstall"));
+              }
+            });
           });
         }
       }else{
-        resolve(ret);
+        return ret;
       }
-    }catch(e){
-      console.log('not a npm project (missing package.json)', e);
-      reject(e);
-    }
-  });
+
+    });
 };
 
 module.exports = AutoInstall;

--- a/lib/index.js
+++ b/lib/index.js
@@ -156,7 +156,7 @@ AutoInstall.prototype.detectMissing = function(directory, options) {
             var temp = _.get(requires, r, []);
             temp.push(f);
             _.set(requires, r, temp);
-            // if(!_(systemPackages).contains(r)){
+            // if(!_.includes(systemPackages, r)){
             //   requires.push(r);
             // }
           });
@@ -168,20 +168,20 @@ AutoInstall.prototype.detectMissing = function(directory, options) {
       // requires = _.uniq(requires);
       // Find missing and unused
       _.forEach(requires, function(v, r) {
-        if(!_.has(packageJson.dependencies, r) && !_.has(packageJson.devDependencies, r) && !_(systemPackages).contains(r)) {
+        if(!_.has(packageJson.dependencies, r) && !_.has(packageJson.devDependencies, r) && !_.includes(systemPackages, r)) {
           ret.missing.push({name: r, files: v});
         }
       });
       if(packageJson.dependencies){
         Object.keys(packageJson.dependencies).forEach(function(d) {
-          if(!_.has(requires, d) && !_.contains(naiConfig.unused, d)){
+          if(!_.has(requires, d) && !_.includes(naiConfig.unused, d)){
             ret.unused.push(d);
           }
         });
       }
       if(packageJson.devDependencies){
         Object.keys(packageJson.devDependencies).forEach(function(d) {
-          if(!_.has(requires, d) && !_.contains(naiConfig.unused, d)){
+          if(!_.has(requires, d) && !_.includes(naiConfig.unused, d)){
             ret.unused.push(d);
           }
         });

--- a/package.json
+++ b/package.json
@@ -21,23 +21,23 @@
     "colors": "^1.1.2",
     "commander": "^2.8.1",
     "debug": "^2.2.0",
-    "esprima": "^2.5.0",
-    "glob": "^5.0.14",
-    "lodash": "^3.10.1",
-    "npm": "^2.13.4",
-    "prompt": "^0.2.14"
+    "esprima": "^3.1.3",
+    "glob": "^7.1.1",
+    "lodash": "^4.17.3",
+    "npm": "^4.0.5",
+    "prompt": "^1.0.0"
   },
   "bin": {
     "nai": "bin/npm-auto-install.js"
   },
   "devDependencies": {
     "chai": "^3.2.0",
-    "chai-as-promised": "^5.1.0",
-    "fs-extra": "^0.23.0",
+    "chai-as-promised": "^6.0.0",
+    "fs-extra": "^1.0.0",
     "gulp": "^3.9.0",
     "gulp-coveralls": "^0.1.4",
-    "gulp-istanbul": "^0.10.0",
-    "gulp-mocha": "^2.1.3",
-    "mocha": "^2.2.5"
+    "gulp-istanbul": "^1.1.1",
+    "gulp-mocha": "^3.0.1",
+    "mocha": "^3.2.0"
   }
 }

--- a/test/auto-install.js
+++ b/test/auto-install.js
@@ -22,6 +22,7 @@ function enableLog(){
 }
 
 beforeEach(function() {
+  this.timeout(5000);
   disableLog();
   try{
     fse.removeSync(TMP_PROJ);
@@ -51,6 +52,7 @@ describe('CheckPackage', function () {
   });
 
   it('install and uninstall', function(){
+    this.timeout(5000);
     fse.copySync('test/data/templateProject2', TMP_PROJ);
     return new AutoInstall().detectMissing(TMP_PROJ, {install: true, force: true, uninstall: true}).then(function(data){
       data.should.deep.equal({


### PR DESCRIPTION
Promises are typically a better way to handle errors, rather than nested try/catch statements (at least, as far as I know). Try/catch tends to be expensive, and should only be used when receiving an unexpected error. With promises, errors can be more eloquently handled and code is more straightforward.

Should be merged after #3 